### PR TITLE
Show guests their own rating and characteristics

### DIFF
--- a/src/entities/RatePlace/ui/RatePlaceWidget/RatePlaceWidget.tsx
+++ b/src/entities/RatePlace/ui/RatePlaceWidget/RatePlaceWidget.tsx
@@ -9,7 +9,8 @@ interface RatePlaceWidgetProps {
   userRating?: number | null;
   reviewId?: string;
   onSubmitRating: (rating: number) => void;
-  handleDeleteMyRating: () => void;
+  /** Omitted for guests: deleting a review needs an account. */
+  handleDeleteMyRating?: () => void;
 }
 
 export const RatePlaceWidget = ({
@@ -30,7 +31,7 @@ export const RatePlaceWidget = ({
             <div className={cls.currentUserRateNumber}>{userRating}</div>
           </div>
           <div className={cls.delEditIcons}>
-            <DeleteIcon className={cls.icon} onClick={handleDeleteMyRating} />
+            {handleDeleteMyRating && <DeleteIcon className={cls.icon} onClick={handleDeleteMyRating} />}
             <EditIcon
               className={cls.icon}
               onClick={() => {

--- a/src/features/RateNow/ui/RateNow.tsx
+++ b/src/features/RateNow/ui/RateNow.tsx
@@ -98,7 +98,7 @@ export const RateNow = ({
         >
           <div className={cls.RateNow}>
             <RatePlaceWidget
-              handleDeleteMyRating={handleDeleteMyRating}
+              handleDeleteMyRating={user ? handleDeleteMyRating : undefined}
               userRating={currentUserReview?.userRating}
               reviewId={currentUserReview?.id}
               onSubmitRating={onSubmitRating}

--- a/src/features/ReviewList/ui/ReviewList.tsx
+++ b/src/features/ReviewList/ui/ReviewList.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { useDeleteReview } from 'shared/api';
+import { useAuthStore } from 'shared/stores/auth';
 import { ReviewCard } from 'shared/ui/ReviewCard';
 import { sortReviews } from '../lib/sortReviews';
 import { type ReviewListProps } from '../types';
@@ -15,6 +16,7 @@ const ReviewListComponent = ({
   onEditReview,
 }: ReviewListProps) => {
   const { handleDeleteReview } = useDeleteReview(placeId);
+  const { user } = useAuthStore();
 
   if (showRateNow) return null;
 
@@ -61,6 +63,7 @@ const ReviewListComponent = ({
             reviewText={review.text ?? undefined}
             userName={review.userName}
             isOwnReview={review.isOwnReview}
+            canDelete={Boolean(user)}
             userAvatar={review.userAvatar ?? undefined}
             setShowRateNow={setShowRateNow}
             handleDeleteReview={handleDeleteReview}

--- a/src/shared/config/apolloClient.ts
+++ b/src/shared/config/apolloClient.ts
@@ -1,11 +1,49 @@
-import { createHttpLink, ApolloClient, InMemoryCache } from '@apollo/client';
+import { createHttpLink, ApolloClient, InMemoryCache, from } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+import { onError } from '@apollo/client/link/error';
+import { clearGuestIdentity, readGuestIdentity } from 'shared/lib/guest/guestStorage';
 
 const httpLink = createHttpLink({
   uri: process.env.VITE_ENV === 'development' ? process.env.VITE_API_URL : process.env.VITE_API_URL_PROD,
   credentials: 'include',
 });
 
+/**
+ * Guest credentials ride on every request, the way the session cookie does.
+ *
+ * They belong here rather than in each operation's variables: reads need them
+ * too — that is how the server knows which rating and which characteristics are
+ * the visitor's own — and putting a secret into query arguments would make it
+ * part of Apollo's cache keys.
+ */
+const guestLink = setContext((_, { headers }) => {
+  const identity = readGuestIdentity();
+
+  if (!identity) return { headers };
+
+  return {
+    headers: {
+      ...headers,
+      'x-guest-id': identity.guestId,
+      'x-guest-secret': identity.guestSecret,
+    },
+  };
+});
+
+/**
+ * Credentials the server no longer accepts are worse than none: they make every
+ * guest action fail until the storage is cleared by hand. Dropping them lets the
+ * next attempt mint a fresh identity.
+ */
+const guestRecoveryLink = onError(({ graphQLErrors }) => {
+  const staleIdentity = graphQLErrors?.some((error) => error.extensions?.code === 'GUEST_IDENTITY_INVALID');
+
+  if (staleIdentity) {
+    clearGuestIdentity();
+  }
+});
+
 export const client = new ApolloClient({
-  link: httpLink,
+  link: from([guestRecoveryLink, guestLink, httpLink]),
   cache: new InMemoryCache(),
 });

--- a/src/shared/lib/guest/guestIdentity.ts
+++ b/src/shared/lib/guest/guestIdentity.ts
@@ -6,56 +6,17 @@ import {
   type CreateGuestIdentityMutation,
 } from 'shared/generated/graphql';
 import { executeRecaptcha } from 'shared/lib/recaptcha';
+import { clearGuestIdentity, type GuestIdentity, readGuestIdentity, writeGuestIdentity } from './guestStorage';
 
 /**
  * Guest identity: the credential that lets an unauthenticated visitor leave a
  * review. It is issued once, after a captcha check, and then replaces the
  * captcha for every later guest action.
  *
- * The pair lives in localStorage, so clearing site data loses the reviews for
- * good — that is the trade for not asking a guest to register.
+ * The pair lives in localStorage. The review itself is public either way — what
+ * is lost with the storage is the proof that it belongs to this visitor, and
+ * with it the ability to edit the review or claim it under an account.
  */
-
-const GUEST_ID_KEY = '3welle:guestId';
-const GUEST_SECRET_KEY = '3welle:guestSecret';
-
-export interface GuestIdentity {
-  guestId: string;
-  guestSecret: string;
-}
-
-const readStorage = (key: string): string | null => {
-  try {
-    return localStorage.getItem(key);
-  } catch {
-    // Private mode and blocked site data both throw on access.
-    return null;
-  }
-};
-
-const writeStorage = (key: string, value: string): void => {
-  try {
-    localStorage.setItem(key, value);
-  } catch {
-    // Nothing to do: the guest simply gets a new identity next time.
-  }
-};
-
-export const readGuestIdentity = (): GuestIdentity | null => {
-  const guestId = readStorage(GUEST_ID_KEY);
-  const guestSecret = readStorage(GUEST_SECRET_KEY);
-
-  return guestId && guestSecret ? { guestId, guestSecret } : null;
-};
-
-export const clearGuestIdentity = (): void => {
-  try {
-    localStorage.removeItem(GUEST_ID_KEY);
-    localStorage.removeItem(GUEST_SECRET_KEY);
-  } catch {
-    // Ignore: an identity we cannot clear is one we also cannot read.
-  }
-};
 
 let pendingIdentity: Promise<GuestIdentity> | null = null;
 
@@ -82,10 +43,10 @@ export const ensureGuestIdentity = async (): Promise<GuestIdentity> => {
       throw new Error('Could not start a guest session');
     }
 
-    writeStorage(GUEST_ID_KEY, identity.guestId);
-    writeStorage(GUEST_SECRET_KEY, identity.guestSecret);
+    const minted = { guestId: identity.guestId, guestSecret: identity.guestSecret };
+    writeGuestIdentity(minted);
 
-    return { guestId: identity.guestId, guestSecret: identity.guestSecret };
+    return minted;
   })();
 
   try {

--- a/src/shared/lib/guest/guestStorage.ts
+++ b/src/shared/lib/guest/guestStorage.ts
@@ -1,0 +1,49 @@
+/**
+ * Where a guest's credentials live between visits.
+ *
+ * Kept free of imports on purpose: the Apollo link reads it while building every
+ * request, and the module that mints identities talks to Apollo. Anything shared
+ * between the two has to sit below both.
+ */
+
+const GUEST_ID_KEY = '3welle:guestId';
+const GUEST_SECRET_KEY = '3welle:guestSecret';
+
+export interface GuestIdentity {
+  guestId: string;
+  guestSecret: string;
+}
+
+const readStorage = (key: string): string | null => {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    // Private mode and blocked site data both throw on access.
+    return null;
+  }
+};
+
+export const readGuestIdentity = (): GuestIdentity | null => {
+  const guestId = readStorage(GUEST_ID_KEY);
+  const guestSecret = readStorage(GUEST_SECRET_KEY);
+
+  return guestId && guestSecret ? { guestId, guestSecret } : null;
+};
+
+export const writeGuestIdentity = ({ guestId, guestSecret }: GuestIdentity): void => {
+  try {
+    localStorage.setItem(GUEST_ID_KEY, guestId);
+    localStorage.setItem(GUEST_SECRET_KEY, guestSecret);
+  } catch {
+    // Nothing to do: the guest simply gets a new identity next time.
+  }
+};
+
+export const clearGuestIdentity = (): void => {
+  try {
+    localStorage.removeItem(GUEST_ID_KEY);
+    localStorage.removeItem(GUEST_SECRET_KEY);
+  } catch {
+    // Ignore: an identity we cannot clear is one we also cannot read.
+  }
+};

--- a/src/shared/lib/guest/index.ts
+++ b/src/shared/lib/guest/index.ts
@@ -1,7 +1,2 @@
-export {
-  claimGuestReviews,
-  clearGuestIdentity,
-  ensureGuestIdentity,
-  readGuestIdentity,
-  type GuestIdentity,
-} from './guestIdentity';
+export { claimGuestReviews, ensureGuestIdentity } from './guestIdentity';
+export { clearGuestIdentity, readGuestIdentity, writeGuestIdentity, type GuestIdentity } from './guestStorage';

--- a/src/shared/ui/ReviewCard/ui/ReviewCard.tsx
+++ b/src/shared/ui/ReviewCard/ui/ReviewCard.tsx
@@ -19,6 +19,8 @@ interface ReviewCardProps {
   rating?: number;
   reviewImages: number;
   isOwnReview?: boolean;
+  /** A guest owns their review and may edit it, but deleting needs an account. */
+  canDelete?: boolean;
   handleDeleteReview?: (id: string) => void;
   setShowRateNow: React.Dispatch<React.SetStateAction<boolean>>;
   createdAt: string;
@@ -37,6 +39,7 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
   rating,
   reviewImages,
   isOwnReview,
+  canDelete,
   handleDeleteReview,
   setShowRateNow,
   createdAt,
@@ -112,7 +115,7 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
         </div>
         <div className={cls.dateAndButtons}>
           <p className={cls.createdAt}>{formatDistanceToNow(new Date(createdAt), { addSuffix: true })}</p>
-          {isOwnReview && handleDeleteReview && (
+          {isOwnReview && (
             <div className={cls.buttons}>
               <EditIcon
                 onClick={() => {
@@ -123,15 +126,17 @@ export const ReviewCard: React.FC<ReviewCardProps> = ({
                 title="Edit my feedback"
               />
 
-              <DeleteIcon
-                onClick={() => {
-                  const isConfirmed = window.confirm('Deleting review. Continue?');
-                  if (!isConfirmed) return;
-                  handleDeleteReview(reviewId);
-                }}
-                className={cls.buttonIcon}
-                title="Delete my review"
-              />
+              {canDelete && handleDeleteReview && (
+                <DeleteIcon
+                  onClick={() => {
+                    const isConfirmed = window.confirm('Deleting review. Continue?');
+                    if (!isConfirmed) return;
+                    handleDeleteReview(reviewId);
+                  }}
+                  className={cls.buttonIcon}
+                  title="Delete my review"
+                />
+              )}
             </div>
           )}
         </div>

--- a/src/widgets/AuthModal/components/GuestReviewSubmitted/ui/GuestReviewSubmitted.tsx
+++ b/src/widgets/AuthModal/components/GuestReviewSubmitted/ui/GuestReviewSubmitted.tsx
@@ -11,8 +11,9 @@ export const GuestReviewSubmitted = ({ onClose, onSignUp }: GuestReviewSubmitted
     <div className={cls.GuestReviewSubmitted}>
       <h2>Thanks for your review!</h2>
       <p>
-        It&apos;s published anonymously. Create an account and we&apos;ll attach it to you — that&apos;s the only way to
-        edit or delete it later ✨
+        It&apos;s live and everyone can see it — just anonymously. Only this browser knows the review is yours: clear
+        its data or open the site elsewhere and the review stays up, but you&apos;ll lose the ability to edit it or put
+        your name on it. Create an account and it&apos;s yours for good ✨
       </p>
       <div className={cls.buttons}>
         <RegularButton onClick={onSignUp}>Create account</RegularButton>


### PR DESCRIPTION
Client half of berlin-coffee-backend#7. Requires that PR to be deployed to have any visible effect, but is safe to ship in either order.

## Why

After #31 a returning guest saw an empty form over a review they had already written, and pressing an already-pressed characteristic silently un-pressed it, because the server had no way to know which interactions were theirs on a read.

## What changed

- **Credentials ride on every request** via an Apollo link instead of being passed to individual mutations. Reads need them as much as writes do, and putting a secret into query variables would have made it part of Apollo's cache keys.
- **Storage moved to its own import-free module.** The link reads it while building each request and the module that mints identities talks to Apollo, so anything shared between the two has to sit below both.
- **An error link drops credentials the server rejects.** Stale ones are worse than none — they fail every guest action until the storage is cleared by hand, whereas dropping them lets the next attempt mint a fresh identity.
- **Delete stays account-only**, so `ReviewCard` now separates *mine* from *deletable* and the rating widget's delete handler is optional. A guest gets the edit control without a delete button that would only fail server-side.
- **New modal copy.** The old text was wrong twice over: it promised registering was the only way to edit — never true of characteristics, and no longer true of anything — and "saved in this browser" read as though the review were private rather than public.

## Note

Deleting a review still requires an account, and that is deliberate: it is the one thing a guest identity cannot do, alongside favourites and the profile. The modal now sells durability instead — the review is public and stays up; what lives in the browser is the proof that it is yours.